### PR TITLE
Add Archiva template renderers and include directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ dist-ssr
 
 # Project directories
 templates
+!src/lib/archiva/templates/
 goals
 docs

--- a/src/lib/archiva/templates/experiment_report.js
+++ b/src/lib/archiva/templates/experiment_report.js
@@ -1,0 +1,83 @@
+import { helpers, fm } from '../renderer.js';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderSection(title, body, format = 'md') {
+  if (!body) return '';
+  if (format === 'html') {
+    return `<section><h2>${escapeHtml(title)}</h2>${body}</section>`;
+  }
+  return `## ${title}\n\n${body}\n`;
+}
+
+function renderMetaTable(meta = {}, format = 'md') {
+  if (!meta || typeof meta !== 'object') return '';
+  const rows = Object.entries(meta).map(([key, value]) => ({
+    Setting: key,
+    Value: typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)
+  }));
+  if (!rows.length) return '';
+  return helpers.tbl(rows, format);
+}
+
+function renderInputs(inputs = {}, format = 'md') {
+  const entries = Object.entries(inputs);
+  if (!entries.length) return '';
+  if (format === 'html') {
+    return `<dl>${entries.map(([key, value]) => `<dt>${escapeHtml(key)}</dt><dd><pre>${escapeHtml(String(value))}</pre></dd>`).join('')}</dl>`;
+  }
+  return entries.map(([key, value]) => `- **${key}:**\n\n${'    ' + String(value).split('\n').join('\n    ')}`).join('\n');
+}
+
+export function render(format = 'md', data = {}) {
+  const frontmatter = fm({
+    title: data.title || 'Experiment Report',
+    workflow_id: data.workflow_id || null,
+    run_id: data.run_id || null,
+    started_at: data.started_at || null,
+    ended_at: data.ended_at || null
+  });
+
+  const stepsTable = helpers.tbl((data.steps || []).map((step, index) => ({
+    Step: `${index + 1}. ${step.name || 'Step'}`,
+    Model: step.model || step.provider || '—',
+    Status: step.status || 'completed',
+    Latency: step.metrics?.latency_ms ? `${step.metrics.latency_ms} ms` : '—',
+    Tokens: step.metrics?.tokens_out ? `${step.metrics.tokens_out}` : '—'
+  })), format);
+
+  if (format === 'html') {
+    const sections = [
+      `<header><h1>${escapeHtml(data.title || 'Experiment Report')}</h1></header>`,
+      renderSection('Hypothesis', `<p>${escapeHtml(data.hypothesis || 'Not documented')}</p>`, format),
+      renderSection('Inputs', renderInputs(data.inputs, format), format),
+      renderSection('Environment & Settings', renderMetaTable(data.meta?.env, format), format),
+      stepsTable ? renderSection('Execution Steps', stepsTable, format) : '',
+      data.discussion ? renderSection('Discussion', `<p>${escapeHtml(data.discussion)}</p>`, format) : '',
+      data.limitations ? renderSection('Limitations', `<p>${escapeHtml(data.limitations)}</p>`, format) : ''
+    ].filter(Boolean);
+    return sections.join('');
+  }
+
+  const parts = [
+    frontmatter,
+    `# ${data.title || 'Experiment Report'}\n`,
+    renderSection('Hypothesis', data.hypothesis || 'Not documented', format),
+    renderSection('Inputs', renderInputs(data.inputs, format) || 'No inputs recorded.', format),
+    renderSection('Environment & Settings', renderMetaTable(data.meta?.env, format) || 'No environment metadata.', format),
+    stepsTable ? renderSection('Execution Steps', stepsTable, format) : '',
+    renderSection('Discussion', data.discussion || 'Pending analysis.', format),
+    renderSection('Limitations', data.limitations || 'Not documented.', format)
+  ].filter(Boolean);
+
+  return parts.join('\n');
+}
+
+export default { render };

--- a/src/lib/archiva/templates/process_journal.js
+++ b/src/lib/archiva/templates/process_journal.js
@@ -1,0 +1,104 @@
+import { helpers, fm } from '../renderer.js';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderList(items, format = 'md') {
+  if (!items?.length) return '';
+  if (format === 'html') {
+    return `<ul>${items.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
+  }
+  return items.map(item => `- ${item}`).join('\n');
+}
+
+function renderSection(title, body, format = 'md') {
+  if (!body) return '';
+  if (format === 'html') {
+    return `<section><h2>${escapeHtml(title)}</h2>${body}</section>`;
+  }
+  return `## ${title}\n\n${body}\n`;
+}
+
+function renderMetadata(data, format = 'md') {
+  const rows = [
+    ['Workflow', data.workflow_id || 'N/A'],
+    ['Run', data.run_id || 'N/A'],
+    ['Time Range', helpers.timeRange(data.started_at, data.ended_at)],
+    ['Status', data.status || 'Completed']
+  ];
+
+  if (format === 'html') {
+    const cells = rows
+      .filter(([, value]) => value)
+      .map(([label, value]) => `<tr><th>${escapeHtml(label)}</th><td>${escapeHtml(value)}</td></tr>`)
+      .join('');
+    return `<table class="meta"><tbody>${cells}</tbody></table>`;
+  }
+
+  return rows
+    .filter(([, value]) => value)
+    .map(([label, value]) => `- **${label}:** ${value}`)
+    .join('\n');
+}
+
+export function render(format = 'md', data = {}) {
+  const summary = data.summary || {};
+  const findings = renderList(summary.findings, format);
+  const nextSteps = renderList(summary.next_steps, format);
+  const stepRows = (data.steps || []).map((step, index) => ({
+    Step: `${index + 1}. ${step.name || 'Step'}`,
+    Model: step.model || '—',
+    Latency: step.metrics?.latency_ms ? `${step.metrics.latency_ms} ms` : '—',
+    Tokens: step.metrics?.tokens_out ? `${step.metrics.tokens_out}` : '—',
+    Notes: step.request?.prompt || step.response || step.notes || ''
+  }));
+
+  const meta = renderMetadata(data, format);
+  const methodDescription = data.method ? escapeHtml(data.method) : '';
+  const contextBody = data.context ? escapeHtml(data.context) : '';
+  const stepsTable = stepRows.length ? helpers.tbl(stepRows, format) : '';
+
+  if (format === 'html') {
+    const header = `\n      <header>\n        <h1>${escapeHtml(data.title || 'Process Journal')}</h1>\n      </header>\n    `;
+    const sections = [
+      meta ? `<section>${meta}</section>` : '',
+      renderSection('Context', `<p>${contextBody}</p>`, format),
+      renderSection('Method', `<pre>${methodDescription}</pre>`, format),
+      findings ? renderSection('Key Findings', findings, format) : '',
+      nextSteps ? renderSection('Next Steps', nextSteps, format) : '',
+      stepsTable ? renderSection('Execution Steps', stepsTable, format) : ''
+    ].filter(Boolean).join('');
+
+    return `\n${header}${sections}`;
+  }
+
+  const frontmatter = fm({
+    title: data.title || 'Process Journal',
+    workflow_id: data.workflow_id || null,
+    run_id: data.run_id || null,
+    started_at: data.started_at || null,
+    ended_at: data.ended_at || null
+  });
+
+  const parts = [
+    frontmatter,
+    `# ${data.title || 'Process Journal'}\n`,
+    meta,
+    '',
+    renderSection('Context', data.context || 'No context provided.', format),
+    renderSection('Method', data.method || 'No method documented.', format),
+    findings ? renderSection('Key Findings', findings, format) : '',
+    nextSteps ? renderSection('Next Steps', nextSteps, format) : '',
+    stepsTable ? renderSection('Execution Steps', stepsTable, format) : ''
+  ].filter(Boolean);
+
+  return parts.join('\n');
+}
+
+export default { render };

--- a/src/lib/archiva/templates/prompt_card.js
+++ b/src/lib/archiva/templates/prompt_card.js
@@ -1,0 +1,108 @@
+import { helpers, fm } from '../renderer.js';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderSection(title, body, format = 'md') {
+  if (!body) return '';
+  if (format === 'html') {
+    return `<section><h2>${escapeHtml(title)}</h2>${body}</section>`;
+  }
+  return `## ${title}\n\n${body}\n`;
+}
+
+function renderPromptSteps(steps = [], format = 'md') {
+  if (!steps.length) return '';
+
+  if (format === 'html') {
+    const items = steps.map((step, index) => {
+      const prompt = step.request?.prompt || step.prompt || '';
+      const response = step.response || step.output || '';
+      return `
+        <article class="prompt-step">
+          <header><h3>Step ${index + 1}: ${escapeHtml(step.name || 'Prompt')}</h3></header>
+          ${prompt ? `<h4>Prompt</h4><pre>${escapeHtml(prompt)}</pre>` : ''}
+          ${response ? `<h4>Response</h4><pre>${escapeHtml(response)}</pre>` : ''}
+          ${step.notes ? `<p>${escapeHtml(step.notes)}</p>` : ''}
+        </article>
+      `;
+    }).join('');
+    return `<div class="prompt-steps">${items}</div>`;
+  }
+
+  return steps.map((step, index) => {
+    const prompt = step.request?.prompt || step.prompt || '';
+    const response = step.response || step.output || '';
+    const lines = [`### Step ${index + 1}: ${step.name || 'Prompt'}`];
+    if (prompt) {
+      lines.push('**Prompt**');
+      lines.push('');
+      lines.push('```');
+      lines.push(prompt);
+      lines.push('```');
+      lines.push('');
+    }
+    if (response) {
+      lines.push('**Response**');
+      lines.push('');
+      lines.push('```');
+      lines.push(response);
+      lines.push('```');
+      lines.push('');
+    }
+    if (step.notes) {
+      lines.push(step.notes);
+      lines.push('');
+    }
+    return lines.join('\n');
+  }).join('\n');
+}
+
+export function render(format = 'md', data = {}) {
+  const frontmatter = fm({
+    title: data.title || 'Prompt Card',
+    workflow_id: data.workflow_id || null,
+    run_id: data.run_id || null,
+    started_at: data.started_at || null,
+    ended_at: data.ended_at || null
+  });
+
+  const metadataRows = [
+    { Label: 'Workflow', Value: data.workflow_id || 'N/A' },
+    { Label: 'Run', Value: data.run_id || 'N/A' },
+    { Label: 'Models Used', Value: [...new Set((data.steps || []).map(step => step.model).filter(Boolean))].join(', ') || 'N/A' },
+    { Label: 'Duration', Value: helpers.timeRange(data.started_at, data.ended_at) }
+  ];
+
+  const metaTable = helpers.tbl(metadataRows, format);
+  const promptSteps = renderPromptSteps(data.steps, format);
+
+  if (format === 'html') {
+    return [
+      `<header><h1>${escapeHtml(data.title || 'Prompt Card')}</h1></header>`,
+      renderSection('Summary', data.summary ? `<p>${escapeHtml(data.summary)}</p>` : '', format),
+      metaTable ? renderSection('Metadata', metaTable, format) : '',
+      promptSteps ? renderSection('Prompt Steps', promptSteps, format) : '',
+      data.notes ? renderSection('Notes', `<p>${escapeHtml(data.notes)}</p>`, format) : ''
+    ].filter(Boolean).join('');
+  }
+
+  const parts = [
+    frontmatter,
+    `# ${data.title || 'Prompt Card'}\n`,
+    data.summary ? renderSection('Summary', data.summary, format) : '',
+    metaTable ? renderSection('Metadata', metaTable, format) : '',
+    promptSteps ? renderSection('Prompt Steps', promptSteps, format) : '',
+    data.notes ? renderSection('Notes', data.notes, format) : ''
+  ].filter(Boolean);
+
+  return parts.join('\n');
+}
+
+export default { render };


### PR DESCRIPTION
## Summary
- add dedicated renderer modules for Archiva process journal, experiment report, and prompt card templates
- allow the new Archiva template directory to be tracked by git

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da46cf9944832099ebdbdd40a2b30a