### PR TITLE
Relax COOP headers to allow postMessage

### DIFF
--- a/server.js
+++ b/server.js
@@ -103,12 +103,15 @@ app.use((req, res, next) => {
   }
 });
 
-// Relax COOP/COEP for OAuth popups and Google One Tap
+// Relax COOP/COEP for OAuth popups, Google One Tap, and third-party embeds
 app.use((req, res, next) => {
-  // Allow popups to communicate back to opener
-  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
-  // Avoid strict COEP that can break third-party iframes; credentialless is a safer default
-  res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+  // Use the most permissive COOP value so OAuth popups and third-party iframes can
+  // communicate via postMessage. Browsers log a console error and block communication
+  // when COOP is "same-origin" or "same-origin-allow-popups".
+  res.setHeader('Cross-Origin-Opener-Policy', 'unsafe-none');
+  // Do not opt-in to COEP so third-party embeds (e.g. YouTube) retain access to
+  // postMessage even when loaded without cross-origin isolation headers.
+  res.removeHeader('Cross-Origin-Embedder-Policy');
   next();
 });
 


### PR DESCRIPTION
## Summary
- set the Cross-Origin-Opener-Policy header to `unsafe-none` so OAuth popups and third-party embeds can use postMessage
- drop the Cross-Origin-Embedder-Policy header to avoid isolating YouTube and similar frames

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da4b46ca84832082e06278ae003c64