### PR TITLE
Restore planner canvas from persisted graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ GenBooth supports OAuth integration with multiple services:
 - `GET /metrics` - Prometheus metrics
 - Legal pages: `/privacy`, `/terms`
 
+## QA Guidance
+
+- **Planner persistence**
+  1. Open the Planner app and create or modify a graph (add a few nodes, connect them, and set a workflow title).
+  2. Navigate away or refresh the browser, then return to the Planner canvas via the app switcher.
+  3. Confirm the previously saved nodes, edges, and title are restored without manual re-importing.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/src/components/PlannerCanvas.jsx
+++ b/src/components/PlannerCanvas.jsx
@@ -356,6 +356,7 @@ export default function PlannerCanvas() {
   const [nodes, setNodes, onNodesChange] = useNodesState(persisted.nodes || []);
   const [edges, setEdges, onEdgesChange] = useEdgesState(persisted.edges || []);
   const [workflowTitle, setWorkflowTitle] = useState(persisted.title || '');
+  const [hasHydrated, setHasHydrated] = useState(() => useStore.persist?.hasHydrated?.() ?? true);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [isGeneratingTitle, setIsGeneratingTitle] = useState(false);
   const [configModalNode, setConfigModalNode] = useState(null);
@@ -366,6 +367,49 @@ export default function PlannerCanvas() {
 
   const rfRef = useRef(null);
   const fileInputRef = useRef(null);
+
+  const nodesSignature = useMemo(() => JSON.stringify(nodes), [nodes]);
+  const edgesSignature = useMemo(() => JSON.stringify(edges), [edges]);
+
+  useEffect(() => {
+    const persistApi = useStore.persist;
+    if (!persistApi?.onFinishHydration) {
+      return;
+    }
+
+    const unsubscribe = persistApi.onFinishHydration(() => {
+      setHasHydrated(true);
+    });
+
+    if (persistApi.hasHydrated?.()) {
+      setHasHydrated(true);
+    }
+
+    return () => unsubscribe?.();
+  }, []);
+
+  useEffect(() => {
+    if (!hasHydrated) return;
+
+    const nextNodes = persisted.nodes || [];
+    const nextEdges = persisted.edges || [];
+    const nextTitle = persisted.title || '';
+
+    const nextNodesSignature = JSON.stringify(nextNodes);
+    const nextEdgesSignature = JSON.stringify(nextEdges);
+
+    if (nodesSignature !== nextNodesSignature) {
+      setNodes(nextNodes);
+    }
+
+    if (edgesSignature !== nextEdgesSignature) {
+      setEdges(nextEdges);
+    }
+
+    if (workflowTitle !== nextTitle) {
+      setWorkflowTitle(nextTitle);
+    }
+  }, [hasHydrated, persisted, nodesSignature, edgesSignature, workflowTitle, setNodes, setEdges, setWorkflowTitle]);
 
   const onConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), [setEdges]);
 


### PR DESCRIPTION
## Summary
- sync the planner canvas with the persisted graph once Zustand hydration completes
- guard node, edge, and title updates to avoid redundant local state churn during persistence
- document QA coverage for verifying planner graph restoration after refresh

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da4f77ed8c832094dfca46e25e7590