### PR TITLE
Improve AI title error handling

### DIFF
--- a/src/components/PlannerCanvas.jsx
+++ b/src/components/PlannerCanvas.jsx
@@ -358,6 +358,7 @@ export default function PlannerCanvas() {
   const [workflowTitle, setWorkflowTitle] = useState(persisted.title || '');
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [isGeneratingTitle, setIsGeneratingTitle] = useState(false);
+  const [titleError, setTitleError] = useState(null);
   const [configModalNode, setConfigModalNode] = useState(null);
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const setActiveApp = useStore.use.actions().setActiveApp;
@@ -753,6 +754,7 @@ export default function PlannerCanvas() {
 
   const handleTitleChange = useCallback((e) => {
     setWorkflowTitle(e.target.value);
+    setTitleError(null);
   }, []);
 
   const handleTitleBlur = useCallback(() => {
@@ -769,9 +771,12 @@ export default function PlannerCanvas() {
   const generateAITitle = useCallback(async () => {
     if (isGeneratingTitle) return; // Prevent double-clicks
 
+    const previousTitle = workflowTitle;
+
     try {
       console.log('Generating AI title...');
       setIsGeneratingTitle(true);
+      setTitleError(null);
 
       const flowData = { nodes, edges };
 
@@ -804,23 +809,27 @@ export default function PlannerCanvas() {
           suggestedTitle = suggestedTitle.replace(/['"]/g, '').trim();
           console.log('Suggested title:', suggestedTitle);
           setWorkflowTitle(suggestedTitle);
+          setTitleError(null);
         } else {
           console.warn('No title in response:', data);
           setWorkflowTitle('AI Generated Flow');
+          setTitleError(null);
         }
       } else {
         console.error('API error:', response.status, response.statusText);
         const errorData = await response.json().catch(() => ({}));
         console.error('Error details:', errorData);
-        setWorkflowTitle(''); // Reset to empty
+        setWorkflowTitle(previousTitle);
+        setTitleError('Unable to generate a new title. Please try again.');
       }
     } catch (error) {
       console.error('Failed to generate AI title:', error);
-      setWorkflowTitle(''); // Reset to empty
+      setWorkflowTitle(previousTitle);
+      setTitleError('Unable to generate a new title. Please try again.');
     } finally {
       setIsGeneratingTitle(false);
     }
-  }, [nodes, edges, isGeneratingTitle, workflowAutoTitleModel]);
+  }, [nodes, edges, isGeneratingTitle, workflowAutoTitleModel, workflowTitle]);
 
   // Persist planner graph on each change
   useEffect(() => {
@@ -834,33 +843,38 @@ export default function PlannerCanvas() {
     <div className="planner-canvas-container">
       {/* Workflow Title in upper left corner */}
       <div className="workflow-title-container">
-        {isEditingTitle ? (
-          <input
-            type="text"
-            value={workflowTitle}
-            onChange={handleTitleChange}
-            onBlur={handleTitleBlur}
-            onKeyPress={handleTitleKeyPress}
-            placeholder="Title your Flow"
-            className="workflow-title-input"
-            autoFocus
-          />
-        ) : (
-          <div
-            className="workflow-title-display"
-            onDoubleClick={handleTitleDoubleClick}
+        <div className="workflow-title-row">
+          {isEditingTitle ? (
+            <input
+              type="text"
+              value={workflowTitle}
+              onChange={handleTitleChange}
+              onBlur={handleTitleBlur}
+              onKeyPress={handleTitleKeyPress}
+              placeholder="Title your Flow"
+              className="workflow-title-input"
+              autoFocus
+            />
+          ) : (
+            <div
+              className="workflow-title-display"
+              onDoubleClick={handleTitleDoubleClick}
+            >
+              {workflowTitle || 'Title your Flow'}
+            </div>
+          )}
+          <button
+            className="btn btn-ai-title"
+            onClick={generateAITitle}
+            disabled={isGeneratingTitle}
+            title={isGeneratingTitle ? "Generating title..." : "Generate title with AI"}
           >
-            {workflowTitle || 'Title your Flow'}
-          </div>
+            <span className="icon">{isGeneratingTitle ? 'hourglass_empty' : 'auto_awesome'}</span>
+          </button>
+        </div>
+        {titleError && (
+          <div className="workflow-title-error">{titleError}</div>
         )}
-        <button
-          className="btn btn-ai-title"
-          onClick={generateAITitle}
-          disabled={isGeneratingTitle}
-          title={isGeneratingTitle ? "Generating title..." : "Generate title with AI"}
-        >
-          <span className="icon">{isGeneratingTitle ? 'hourglass_empty' : 'auto_awesome'}</span>
-        </button>
       </div>
 
       <div className="planner-toolbar">

--- a/src/styles/components/planner.css
+++ b/src/styles/components/planner.css
@@ -98,6 +98,13 @@
   left: var(--spacing-10);
   z-index: var(--z-index-dropdown);
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+}
+
+.workflow-title-row {
+  display: flex;
   align-items: center;
   gap: var(--spacing-4);
 }
@@ -150,6 +157,14 @@
 .btn-ai-title:hover {
   background: var(--interactive-secondary-hover);
   transform: scale(1.05);
+}
+
+.workflow-title-error {
+  color: var(--surface-error);
+  font-size: var(--typography-font-size-sm);
+  background: rgba(255, 77, 77, 0.15);
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-sm);
 }
 
 .planner-toolbar {


### PR DESCRIPTION
## Summary
- preserve the previous workflow title when AI generation starts and restore it on failures
- add inline error messaging so users understand why the title was unchanged
- adjust planner title layout styles to accommodate the new status feedback

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da4f9cd6048320aa59517fc715a1c2