### PR TITLE
feat: add glassmorphism to booth footer

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,12 @@
   --border-accent: #1e88e5;
   --border-dashed: #333;
 
+  --glass-panel-bg: rgba(12, 12, 12, 0.72);
+  --glass-panel-border: rgba(255, 255, 255, 0.1);
+  --glass-panel-shadow: 0 20px 40px rgba(0, 0, 0, 0.55);
+  --glass-divider-strong: rgba(255, 255, 255, 0.16);
+  --glass-backdrop-filter: blur(18px);
+
   --backdrop-filter: blur(10px);
 
   --color-selection-bg: #fff;
@@ -74,6 +80,12 @@
   --border-secondary: #dcdfe2;
   --border-accent: #1e88e5;
   --border-dashed: #ced0d4;
+
+  --glass-panel-bg: rgba(255, 255, 255, 0.78);
+  --glass-panel-border: rgba(15, 23, 42, 0.12);
+  --glass-panel-shadow: 0 18px 36px rgba(15, 23, 42, 0.15);
+  --glass-divider-strong: rgba(15, 23, 42, 0.18);
+  --glass-backdrop-filter: blur(18px);
 
   --backdrop-filter: blur(10px);
 
@@ -3624,8 +3636,13 @@ main.workflows-layout .right-column {
 .booth-footer {
   flex-shrink: 0;
   padding: var(--spacing-10);
-  border-top: 1px solid var(--border-primary);
-  background: var(--bg-panel);
+  border-top: 1px solid var(--glass-panel-border);
+  background:
+    linear-gradient(to bottom, var(--glass-divider-strong) 0%, transparent 35%),
+    var(--glass-panel-bg);
+  backdrop-filter: var(--glass-backdrop-filter);
+  -webkit-backdrop-filter: var(--glass-backdrop-filter);
+  box-shadow: var(--glass-panel-shadow);
   max-height: 200px;
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
## Summary
- add glassmorphism design tokens for translucent booth footer backgrounds, borders, and shadows in both themes
- restyle the booth footer to use the new glass tokens with layered gradients while preserving layout constraints

## Testing
- Not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da5bdb2a38832093a1b38e59526761