### PR TITLE
Add provider-aware image booth flow and DrawThings support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tokens:clean": "rm -rf src/styles/tokens/tokens-*.css src/styles/tokens/tokens.js tokens/build",
     "tokens:audit": "node scripts/audit-css.js",
     "tokens:validate": "node scripts/validate-tokens.js",
+    "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest",
     "test:auth": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest tests/auth.routes.test.js"
   },
   "dependencies": {

--- a/src/components/BoothViewer.jsx
+++ b/src/components/BoothViewer.jsx
@@ -2,11 +2,13 @@
  * @license
  * SPDX-License-Identifier: Apache-2.0
 */
+import { useMemo } from 'react';
 import useStore from '../lib/store';
 import { generateImage } from '../lib/actions';
 import ImageUploader from './ImageUploader';
 import modes from '../lib/modes';
 import descriptions from '../lib/descriptions';
+import { getImageProviderLabel, DEFAULT_IMAGE_MODELS } from '../lib/imageProviders';
 
 const getModeDetails = (modeKey) => {
     for (const [categoryName, category] of Object.entries(modes)) {
@@ -34,7 +36,34 @@ export default function BoothViewer() {
     const isGenerating = useStore.use.isGenerating();
     const activeModeKey = useStore.use.activeModeKey();
     const generationError = useStore.use.generationError();
+    const connectedServices = useStore.use.connectedServices();
+    const imageProvider = useStore.use.imageProvider();
+    const imageModel = useStore.use.imageModel();
+    const setImageProvider = useStore((state) => state.actions.setImageProvider);
+    const setImageModel = useStore((state) => state.actions.setImageModel);
     const modeDetails = getModeDetails(activeModeKey);
+
+    const providerOptions = useMemo(() => {
+        const options = [
+            { value: 'gemini', label: getImageProviderLabel('gemini') }
+        ];
+
+        if (connectedServices.openai?.connected) {
+            options.push({ value: 'openai', label: getImageProviderLabel('openai') });
+        }
+
+        if (connectedServices.drawthings?.connected) {
+            options.push({ value: 'drawthings', label: getImageProviderLabel('drawthings') });
+        }
+
+        if (imageProvider && !options.some(option => option.value === imageProvider)) {
+            options.unshift({ value: imageProvider, label: getImageProviderLabel(imageProvider) });
+        }
+
+        return options;
+    }, [connectedServices, imageProvider]);
+
+    const currentModelValue = imageModel ?? DEFAULT_IMAGE_MODELS[imageProvider] ?? '';
 
     if (!inputImage) {
         return <ImageUploader />;
@@ -70,6 +99,34 @@ export default function BoothViewer() {
                 </div>
 
                 <div className="booth-actions">
+                    <div className="provider-controls">
+                        <label htmlFor="image-provider-select" className="provider-label">
+                            Image Provider
+                        </label>
+                        <select
+                            id="image-provider-select"
+                            value={imageProvider}
+                            onChange={(e) => setImageProvider(e.target.value)}
+                            className="provider-select"
+                        >
+                            {providerOptions.map(option => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                        <label htmlFor="image-provider-model" className="provider-label secondary">
+                            Model (optional)
+                        </label>
+                        <input
+                            id="image-provider-model"
+                            type="text"
+                            value={currentModelValue || ''}
+                            onChange={(e) => setImageModel(e.target.value)}
+                            placeholder={DEFAULT_IMAGE_MODELS[imageProvider] || 'Leave blank for provider default'}
+                            className="provider-model-input"
+                        />
+                    </div>
                     <button
                         className="upload-new-btn secondary"
                         onClick={() => useStore.setState({ inputImage: null, outputImage: null })}

--- a/src/lib/imageProviders.js
+++ b/src/lib/imageProviders.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const IMAGE_PROVIDERS = [
+  {
+    id: 'gemini',
+    label: 'Gemini (Google)',
+    defaultModel: 'gemini-2.5-flash-image-preview',
+    alwaysAvailable: true
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI (gpt-image-1)',
+    defaultModel: 'gpt-image-1',
+    alwaysAvailable: false
+  },
+  {
+    id: 'drawthings',
+    label: 'DrawThings (Local)',
+    defaultModel: null,
+    alwaysAvailable: false
+  }
+];
+
+export const DEFAULT_IMAGE_MODELS = IMAGE_PROVIDERS.reduce((acc, provider) => {
+  acc[provider.id] = provider.defaultModel ?? null;
+  return acc;
+}, {});
+
+export const ALWAYS_AVAILABLE_IMAGE_PROVIDERS = new Set(
+  IMAGE_PROVIDERS.filter((provider) => provider.alwaysAvailable).map((provider) => provider.id)
+);
+
+export function getImageProviderLabel(providerId) {
+  const provider = IMAGE_PROVIDERS.find((p) => p.id === providerId);
+  return provider ? provider.label : providerId;
+}
+
+export function getDefaultImageModel(providerId) {
+  return DEFAULT_IMAGE_MODELS[providerId] ?? null;
+}

--- a/tests/image.routes.test.js
+++ b/tests/image.routes.test.js
@@ -1,0 +1,211 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+
+const verifyJWTMock = jest.fn();
+
+const requireAuthMock = jest.fn((req, res, next) => {
+  const token = req.cookies?.auth_token || req.headers?.authorization?.replace('Bearer ', '');
+
+  if (!token) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  try {
+    const user = verifyJWTMock(token);
+    req.user = user;
+    return next();
+  } catch (error) {
+    return res.status(401).json({ error: 'Invalid authentication token' });
+  }
+});
+
+const optionalAuthMock = jest.fn((req, _res, next) => {
+  const token = req.cookies?.auth_token || req.headers?.authorization?.replace('Bearer ', '');
+  if (token) {
+    try {
+      const user = verifyJWTMock(token);
+      req.user = user;
+    } catch (error) {
+      // ignore invalid tokens for optional auth
+    }
+  }
+  next();
+});
+
+jest.unstable_mockModule('../src/lib/auth.js', () => ({
+  verifyGoogleToken: jest.fn(),
+  generateJWT: jest.fn(),
+  verifyJWT: verifyJWTMock,
+  requireAuth: requireAuthMock,
+  optionalAuth: optionalAuthMock,
+}));
+
+jest.unstable_mockModule('../src/lib/logger.js', () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }
+}));
+
+const serverModule = await import('../server.js');
+const { app, geminiBootstrap } = serverModule;
+
+geminiBootstrap.initializeGeminiAPI = jest.fn().mockResolvedValue();
+const geminiClient = { models: { generateContent: jest.fn() } };
+geminiBootstrap.setClient(geminiClient);
+
+const originalFetch = global.fetch;
+
+beforeAll(() => {
+  global.fetch = jest.fn();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+let userCounter = 0;
+const nextUser = () => {
+  userCounter += 1;
+  return {
+    email: `image-tester+${userCounter}@code.berlin`,
+    name: 'Image Tester'
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch.mockReset();
+  global.fetch.mockImplementation(() => Promise.reject(new Error('Unexpected fetch invocation')));
+  geminiClient.models.generateContent.mockReset();
+});
+
+describe('POST /api/image/generate', () => {
+  it('generates an image via Gemini by default', async () => {
+    const user = nextUser();
+    verifyJWTMock.mockImplementation(() => user);
+
+    geminiClient.models.generateContent.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { inlineData: { data: 'AAA', mimeType: 'image/png' } }
+            ]
+          }
+        }
+      ]
+    });
+
+    const response = await request(app)
+      .post('/api/image/generate')
+      .set('Cookie', ['auth_token=test'])
+      .send({
+        provider: 'gemini',
+        prompt: 'hello world',
+        image: 'data:image/png;base64,INPUT',
+        model: 'gemini-2.5-flash-image-preview'
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.image).toBe('data:image/png;base64,AAA');
+    expect(geminiClient.models.generateContent).toHaveBeenCalled();
+  });
+
+  it('uses OpenAI when the provider is openai', async () => {
+    const user = nextUser();
+    verifyJWTMock.mockImplementation(() => user);
+
+    await request(app)
+      .post('/api/services/openai/connect')
+      .set('Cookie', ['auth_token=test'])
+      .send({ apiKey: 'sk-test' })
+      .expect(200);
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ b64_json: 'OPENAI' }] })
+    });
+
+    const response = await request(app)
+      .post('/api/image/generate')
+      .set('Cookie', ['auth_token=test'])
+      .send({
+        provider: 'openai',
+        prompt: 'create art',
+        image: 'data:image/png;base64,INPUT',
+        model: 'gpt-image-1'
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.image).toBe('data:image/png;base64,OPENAI');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/images/edits',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('dispatches to DrawThings when configured', async () => {
+    const user = nextUser();
+    verifyJWTMock.mockImplementation(() => user);
+
+    await request(app)
+      .post('/api/services/drawthings/connect')
+      .set('Cookie', ['auth_token=test'])
+      .send({ url: 'http://127.0.0.1:5678', transport: 'http' })
+      .expect(200);
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ image: 'DRAW' })
+    });
+
+    const response = await request(app)
+      .post('/api/image/generate')
+      .set('Cookie', ['auth_token=test'])
+      .send({
+        provider: 'drawthings',
+        prompt: 'stylize',
+        image: 'data:image/png;base64,INPUT'
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.image).toBe('data:image/png;base64,DRAW');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:5678/v1/generate',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('returns a friendly error when a provider is rate limited', async () => {
+    const user = nextUser();
+    verifyJWTMock.mockImplementation(() => user);
+
+    await request(app)
+      .post('/api/services/openai/connect')
+      .set('Cookie', ['auth_token=test'])
+      .send({ apiKey: 'sk-test' })
+      .expect(200);
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: { message: 'Quota reached' } })
+    });
+
+    const response = await request(app)
+      .post('/api/image/generate')
+      .set('Cookie', ['auth_token=test'])
+      .send({
+        provider: 'openai',
+        prompt: 'rate limit check',
+        image: 'data:image/png;base64,INPUT'
+      });
+
+    expect(response.status).toBe(429);
+    expect(response.body).toEqual({ error: 'Quota reached', code: 'RATE_LIMIT' });
+  });
+});


### PR DESCRIPTION
## Summary
- add DrawThings connection details and provider selection state so the booth can choose Gemini, OpenAI, or local endpoints
- route image generation through a new backend API that normalizes Gemini/OpenAI/DrawThings responses and updates the llm helper accordingly
- cover the new flows with integration tests and expose a project-wide jest script

## Testing
- npm test -- tests/auth.routes.test.js tests/image.routes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da5bd3ee508320a9046f6d2dcf9dc2