### PR TITLE
Fix hook order in BoothViewer

### DIFF
--- a/src/components/BoothViewer.jsx
+++ b/src/components/BoothViewer.jsx
@@ -43,6 +43,7 @@ export default function BoothViewer() {
     const setImageProvider = useStore((state) => state.actions.setImageProvider);
     const setImageModel = useStore((state) => state.actions.setImageModel);
     const modeDetails = getModeDetails(activeModeKey);
+    const fileInputRef = useRef(null);
 
     const providerOptions = useMemo(() => {
         const options = [
@@ -78,8 +79,6 @@ export default function BoothViewer() {
             </div>
         );
     }
-
-    const fileInputRef = useRef(null);
 
     const handleFileSelection = async (file) => {
         if (!file) return;


### PR DESCRIPTION
## Summary
- initialize the BoothViewer file input ref before conditional early returns
- avoid conditional hook usage that caused a React hook order error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da63151bb8832096209807488075e1